### PR TITLE
crates/avalanche-proto: add PROTOCOL_VERSION and bump v0.15.1

### DIFF
--- a/crates/avalanche-proto/Cargo.toml
+++ b/crates/avalanche-proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avalanche-proto"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 rust-version = "1.61"
 publish = true

--- a/crates/avalanche-proto/src/lib.rs
+++ b/crates/avalanche-proto/src/lib.rs
@@ -1,3 +1,6 @@
 pub mod grpcutil;
 
 include!("gen/mod.rs");
+
+/// ref. https://github.com/ava-labs/avalanchego/blob/v1.7.13/vms/rpcchainvm/vm.go
+pub const PROTOCOL_VERSION: &str = env!("CARGO_PKG_VERSION_MINOR");


### PR DESCRIPTION
This PR adds a `PROTOCOL_VERSION` constant based on the crates minor version and bumps crate to v0.15.1. 

Signed-off-by: Sam Batschelet <sam.batschelet@avalabs.org>