### PR TITLE
Auto avalanchego

### DIFF
--- a/scripts/tests.e2e.sh
+++ b/scripts/tests.e2e.sh
@@ -7,50 +7,11 @@ if ! [[ "$0" =~ scripts/tests.e2e.sh ]]; then
   exit 255
 fi
 
-AVALANCHEGO_VERSION=$1
-if [[ -z "${AVALANCHEGO_VERSION}" ]]; then
-  echo "Missing avalanchego version argument!"
-  echo "Usage: ${0} [AVALANCHEGO_VERSION]" >> /dev/stderr
-  exit 255
-fi
-
-echo "Running with:"
-echo AVALANCHEGO_VERSION: ${AVALANCHEGO_VERSION}
-
-############################
-# download avalanchego
-# https://github.com/ava-labs/avalanchego/releases
-GOARCH=$(go env GOARCH)
-GOOS=$(go env GOOS)
-DOWNLOAD_URL=https://github.com/ava-labs/avalanchego/releases/download/v${AVALANCHEGO_VERSION}/avalanchego-linux-${GOARCH}-v${AVALANCHEGO_VERSION}.tar.gz
-DOWNLOAD_PATH=/tmp/avalanchego.tar.gz
-if [[ ${GOOS} == "darwin" ]]; then
-  DOWNLOAD_URL=https://github.com/ava-labs/avalanchego/releases/download/v${AVALANCHEGO_VERSION}/avalanchego-macos-v${AVALANCHEGO_VERSION}.zip
-  DOWNLOAD_PATH=/tmp/avalanchego.zip
-fi
-
-rm -rf /tmp/avalanchego-v${AVALANCHEGO_VERSION}
-rm -f ${DOWNLOAD_PATH}
-
-echo "downloading avalanchego ${AVALANCHEGO_VERSION} at ${DOWNLOAD_URL}"
-curl -L ${DOWNLOAD_URL} -o ${DOWNLOAD_PATH}
-
-echo "extracting downloaded avalanchego"
-if [[ ${GOOS} == "linux" ]]; then
-  tar xzvf ${DOWNLOAD_PATH} -C /tmp
-elif [[ ${GOOS} == "darwin" ]]; then
-  unzip ${DOWNLOAD_PATH} -d /tmp/avalanchego-build
-  mv /tmp/avalanchego-build/build /tmp/avalanchego-v${AVALANCHEGO_VERSION}
-fi
-find /tmp/avalanchego-v${AVALANCHEGO_VERSION}
-
-AVALANCHEGO_PATH=/tmp/avalanchego-v${AVALANCHEGO_VERSION}/avalanchego
-AVALANCHEGO_PLUGIN_DIR=/tmp/avalanchego-v${AVALANCHEGO_VERSION}/plugins
-
 #################################
 # download avalanche-network-runner
 # https://github.com/ava-labs/avalanche-network-runner
 # TODO: use "go install -v github.com/ava-labs/avalanche-network-runner/cmd/avalanche-network-runner@v${NETWORK_RUNNER_VERSION}"
+GOOS=$(go env GOOS) # ensures that the compatible network runner version is downloaded for this machine
 NETWORK_RUNNER_VERSION=1.1.0
 DOWNLOAD_PATH=/tmp/avalanche-network-runner.tar.gz
 DOWNLOAD_URL=https://github.com/ava-labs/avalanche-network-runner/releases/download/v${NETWORK_RUNNER_VERSION}/avalanche-network-runner_${NETWORK_RUNNER_VERSION}_linux_amd64.tar.gz
@@ -77,12 +38,12 @@ server \
 --port=":12342" \
 --grpc-gateway-port=":12343" &
 NETWORK_RUNNER_PID=${!}
+sleep 5 # sleep to ensure that network runner initializes before e2e tests begin
 
 #################################
 # do not run in parallel, to run in sequence
 echo "running e2e tests"
 NETWORK_RUNNER_GRPC_ENDPOINT=http://127.0.0.1:12342 \
-NETWORK_RUNNER_AVALANCHEGO_PATH=${AVALANCHEGO_PATH} \
 RUST_LOG=debug \
 cargo test --all-features --package e2e -- --show-output --nocapture
 

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -11,6 +11,7 @@ homepage = "https://avax.network"
 [dependencies]
 
 [dev-dependencies]
+avalanche-installer = "0.0.4"
 avalanche-network-runner-sdk = { version = "0.0.1" }
 env_logger = "0.9.0"
 log = "0.4.17"


### PR DESCRIPTION
The e2e test now installs avalanchego via https://docs.rs/crate/avalanche-installer/0.0.3.  