### PR TITLE
vm: notify engine of new block

### DIFF
--- a/mini-kvvm/src/chain/vm.rs
+++ b/mini-kvvm/src/chain/vm.rs
@@ -14,4 +14,5 @@ pub struct Context {
 pub trait Vm: avalanche_types::rpcchainvm::vm::Vm {
     async fn is_bootstrapped(&self) -> bool;
     async fn submit(&self, txs: Vec<Transaction>) -> Result<()>;
+    async fn notify_block_ready(&self);
 }


### PR DESCRIPTION
Ideally we would have a compete block builder but as MVP lets notify engine on new block manually when build_block is called via RPC.

Signed-off-by: Sam Batschelet <sam.batschelet@avalabs.org>