### PR TITLE
api: add alias

### DIFF
--- a/spacesvm/src/api/mod.rs
+++ b/spacesvm/src/api/mod.rs
@@ -13,16 +13,16 @@ use crate::chain::{
 
 #[rpc]
 pub trait Service {
-    #[rpc(name = "ping")]
+    #[rpc(name = "ping", alias("spacesvm.ping"))]
     fn ping(&self) -> BoxFuture<Result<PingResponse>>;
 
-    #[rpc(name = "issue_tx")]
+    #[rpc(name = "issueTx", alias("spacesvm.issueTx"))]
     fn issue_tx(&self, params: IssueTxArgs) -> BoxFuture<Result<IssueTxResponse>>;
 
-    #[rpc(name = "decode_tx")]
+    #[rpc(name = "decodeTx", alias("spacesvm.decodeTx"))]
     fn decode_tx(&self, params: DecodeTxArgs) -> BoxFuture<Result<DecodeTxResponse>>;
 
-    #[rpc(name = "resolve")]
+    #[rpc(name = "resolve", alias("spacesvm.resolve"))]
     fn resolve(&self, params: ResolveArgs) -> BoxFuture<Result<ResolveResponse>>;
 }
 

--- a/spacesvm/src/api/rpc.rs
+++ b/spacesvm/src/api/rpc.rs
@@ -8,9 +8,3 @@ struct Request {
     params: Option<serde_json::Value>,
     id: serde_json::Value,
 }
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn test_request() {}
-}


### PR DESCRIPTION
This Pr normalizes the RPC naming to camelCase and adds an alias to RPC with VM name to align with examples.

```
curl -X POST --data '{
    "jsonrpc": "2.0",
    "id"     : 1,
    "method" : "spacesvm.ping",
    "params" : []
}' 
```

Signed-off-by: Sam Batschelet <sam.batschelet@avalabs.org>