### PR TITLE
e2e: add client tests

### DIFF
--- a/scripts/tests.e2e.sh
+++ b/scripts/tests.e2e.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
 set -e
 
-# build spacesvm-rs binary
+# build spacesvm binary
 # ./scripts/build.release.sh
 #
 # download from github, keep network running
-# VM_PLUGIN_PATH=$(pwd)/target/release/spacesvm-rs ./scripts/tests.e2e.sh
+# VM_PLUGIN_PATH=$(pwd)/target/release/spacesvm ./scripts/tests.e2e.sh
 #
 # download from github, shut down network
-# NETWORK_RUNNER_ENABLE_SHUTDOWN=1 VM_PLUGIN_PATH=$(pwd)/target/release/spacesvm-rs ./scripts/tests.e2e.sh
+# NETWORK_RUNNER_ENABLE_SHUTDOWN=1 VM_PLUGIN_PATH=$(pwd)/target/release/spacesvm ./scripts/tests.e2e.sh
 #
 # use custom avalanchego binary
-# VM_PLUGIN_PATH=$(pwd)/target/release/timestampvm ./scripts/tests.e2e.sh ~/go/src/github.com/ava-labs/avalanchego/build/avalanchego
+# VM_PLUGIN_PATH=$(pwd)/target/release/spacesvm ./scripts/tests.e2e.sh ~/go/src/github.com/ava-labs/avalanchego/build/avalanchego
 #
 if ! [[ "$0" =~ scripts/tests.e2e.sh ]]; then
   echo "must be run from repository root"

--- a/spaces-cli/Cargo.toml
+++ b/spaces-cli/Cargo.toml
@@ -17,7 +17,7 @@ clap = { version = "4.0", features = ["derive"] }
 hex = "0.4.3"
 jsonrpc-core = "18.0.0"
 log = "0.4.17"
-serde = { version = "1.0.147", features = ["derive"] }
-serde_json = "1.0.87" 
+serde = { version = "1.0.148", features = ["derive"] }
+serde_json = "1.0.89" 
 spacesvm = { path = "../spacesvm" }
-tokio = { version = "1.22.0", features = ["full"] }
+tokio = { version = "1.22.0", features = [] }

--- a/spaces-cli/src/bin/spaces-cli/main.rs
+++ b/spaces-cli/src/bin/spaces-cli/main.rs
@@ -43,8 +43,8 @@ struct Cli {
     #[command(subcommand)]
     command: Command,
 }
-
-fn main() -> Result<(), Box<dyn error::Error>> {
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn error::Error>> {
     let cli = Cli::parse();
 
     let private_key = get_or_create_pk(&cli.private_key_file)?;

--- a/spaces-cli/src/bin/spaces-cli/main.rs
+++ b/spaces-cli/src/bin/spaces-cli/main.rs
@@ -84,9 +84,9 @@ fn main() -> Result<(), Box<dyn error::Error>> {
 /// Takes a TX command and returns transaction data.
 fn command_to_tx(command: Command) -> std::io::Result<TransactionData> {
     match command {
-        Command::Claim { space } => Ok(claim_tx(space)),
-        Command::Set { space, key, value } => Ok(set_tx(space, key, value.as_bytes().to_vec())),
-        Command::Delete { space, key } => Ok(delete_tx(space, key)),
+        Command::Claim { space } => Ok(claim_tx(&space)),
+        Command::Set { space, key, value } => Ok(set_tx(&space, &key, &value)),
+        Command::Delete { space, key } => Ok(delete_tx(&space, &key)),
         _ => Err(std::io::Error::new(
             std::io::ErrorKind::Other,
             "not a supported tx",

--- a/spacesvm/Cargo.toml
+++ b/spacesvm/Cargo.toml
@@ -15,14 +15,14 @@ name = "spacesvm"
 path = "src/bin/spaces/main.rs"
 
 [dependencies]
-avalanche-types = { version = "0.0.143", features = ["subnet"] }
+avalanche-types = { version = "0.0.144", features = ["subnet"] }
 byteorder = "1.4.3"
-chrono = "0.4.22"
+chrono = "0.4.23"
 crossbeam-channel = "0.5.6"
 derivative = "2.2.0"
 dyn-clone = "1.0.9"
 ethereum-types = { version = "0.14.0" }
-clap = { version = "4.0.22", features = ["cargo", "derive"] }
+clap = { version = "4.0.27", features = ["cargo", "derive"] }
 eip-712 = "0.1.0"
 env_logger = "0.10.0"
 hex = "0.4.3"
@@ -32,15 +32,15 @@ jsonrpc-core = "18.0.0"
 jsonrpc-core-client = { version = "18.0.0" }
 jsonrpc-derive = "18.0"
 log = "0.4.17"
-lru = "0.8.0"
+lru = "0.8.1"
 prost = "0.11.2"
 ripemd = "0.1.3"
 semver = "1.0.14"
-serde = { version = "1.0.147", features = ["derive"] }
-serde_json = "1.0.87"
+serde = { version = "1.0.148", features = ["derive"] }
+serde_json = "1.0.89"
 serde_yaml = "0.9.14"
 sha3 = "0.10.6"
-tokio = { version = "1.21.2", features = ["fs", "rt-multi-thread"] }
+tokio = { version = "1.22.0", features = ["fs", "rt-multi-thread"] }
 tokio-stream = { version = "0.1.11", features = ["net"] }
 tonic = { version = "0.8.2", features = ["gzip"] }
 tonic-health = "0.7"
@@ -48,7 +48,7 @@ typetag = "0.2"
 
 [dev-dependencies] 
 jsonrpc-tcp-server = "18.0.0"
-futures-test = "0.3.24"
+futures-test = "0.3.25"
 
 [[test]]
 name = "integration"

--- a/spacesvm/Cargo.toml
+++ b/spacesvm/Cargo.toml
@@ -15,7 +15,7 @@ name = "spacesvm"
 path = "src/bin/spaces/main.rs"
 
 [dependencies]
-avalanche-types = { version = "0.0.140", features = ["subnet"] }
+avalanche-types = { version = "0.0.143", features = ["subnet"] }
 byteorder = "1.4.3"
 chrono = "0.4.22"
 crossbeam-channel = "0.5.6"

--- a/spacesvm/Cargo.toml
+++ b/spacesvm/Cargo.toml
@@ -24,7 +24,7 @@ dyn-clone = "1.0.9"
 ethereum-types = { version = "0.14.0" }
 clap = { version = "4.0.22", features = ["cargo", "derive"] }
 eip-712 = "0.1.0"
-env_logger = "0.9.3"
+env_logger = "0.10.0"
 hex = "0.4.3"
 http = "0.2.8"
 hyper = "0.14.23"

--- a/spacesvm/src/api/client.rs
+++ b/spacesvm/src/api/client.rs
@@ -177,29 +177,29 @@ impl Client<HttpConnector> {
     }
 }
 
-pub fn claim_tx(space: String) -> TransactionData {
+pub fn claim_tx(space: &str) -> TransactionData {
     TransactionData {
         typ: TransactionType::Claim,
-        space,
+        space: space.to_owned(),
         key: String::new(),
         value: vec![],
     }
 }
 
-pub fn set_tx(space: String, key: String, value: Vec<u8>) -> TransactionData {
+pub fn set_tx(space: &str, key: &str, value: &str) -> TransactionData {
     TransactionData {
         typ: TransactionType::Set,
-        space,
-        key,
-        value,
+        space: space.to_owned(),
+        key: key.to_owned(),
+        value: value.as_bytes().to_vec(),
     }
 }
 
-pub fn delete_tx(space: String, key: String) -> TransactionData {
+pub fn delete_tx(space: &str, key: &str) -> TransactionData {
     TransactionData {
         typ: TransactionType::Delete,
-        space,
-        key,
+        space: space.to_owned(),
+        key: key.to_owned(),
         value: vec![],
     }
 }

--- a/spacesvm/src/bin/spaces/main.rs
+++ b/spacesvm/src/bin/spaces/main.rs
@@ -45,7 +45,7 @@ async fn main() -> Result<()> {
     ) = tokio::sync::broadcast::channel(1);
 
     info!("starting spacesvm-rs");
-    let vm_server = subnet::rpc::vm::server::Server::new(Box::new(vm::ChainVm::new()), stop_ch_tx);
+    let vm_server = subnet::rpc::vm::server::Server::new(vm::ChainVm::new(), stop_ch_tx);
 
     subnet::rpc::plugin::serve(vm_server, stop_ch_rx)
         .await

--- a/spacesvm/tests/vm/mod.rs
+++ b/spacesvm/tests/vm/mod.rs
@@ -138,7 +138,7 @@ async fn test_api() {
     let body = std::str::from_utf8(&resp.body()).unwrap();
     log::info!("ping response {}", body);
 
-    let tx_data = claim_tx("test_claim".to_owned());
+    let tx_data = claim_tx("test_claim");
     let arg_value = serde_json::to_value(&DecodeTxArgs { tx_data }).unwrap();
 
     let (_id, json_str) = client.raw_request("decodeTx", &Params::Array(vec![arg_value]));

--- a/spacesvm/tests/vm/mod.rs
+++ b/spacesvm/tests/vm/mod.rs
@@ -113,7 +113,10 @@ async fn test_api() {
     let client = spacesvm::api::client::Client::new(http::Uri::from_static("http://test.url"));
 
     // ping
-    let (_id, json_str) = client.raw_request("ping", &Params::None).await;
+    let (_id, json_str) = client
+        .raw_request("ping", &Params::None)
+        .await
+        .expect("raw_request success");
     let req = http::request::Builder::new()
         .body(json_str.as_bytes().to_vec())
         .unwrap();
@@ -141,7 +144,8 @@ async fn test_api() {
 
     let (_id, json_str) = client
         .raw_request("decodeTx", &Params::Array(vec![arg_value]))
-        .await;
+        .await
+        .expect("raw_request success");
     log::info!("decodeTx request: {}", json_str);
     let req = http::request::Builder::new()
         .body(json_str.as_bytes().to_vec())

--- a/spacesvm/tests/vm/mod.rs
+++ b/spacesvm/tests/vm/mod.rs
@@ -139,9 +139,10 @@ async fn test_api() {
     log::info!("ping response {}", body);
 
     let tx_data = claim_tx("test_claim".to_owned());
-    let arg_bytes = serde_json::to_value(&DecodeTxArgs { tx_data }).unwrap();
+    let arg_value = serde_json::to_value(&DecodeTxArgs { tx_data }).unwrap();
 
-    let (_id, json_str) = client.raw_request("decodeTx", &Params::Array(vec![arg_bytes]));
+    let (_id, json_str) = client.raw_request("decodeTx", &Params::Array(vec![arg_value]));
+    log::info!("decodeTx request: {}", json_str);
     let req = http::request::Builder::new()
         .body(json_str.as_bytes().to_vec())
         .unwrap();

--- a/spacesvm/tests/vm/mod.rs
+++ b/spacesvm/tests/vm/mod.rs
@@ -26,8 +26,10 @@ async fn test_api() {
 
     // setup stop channel for grpc services.
     let (stop_ch_tx, stop_ch_rx): (Sender<()>, Receiver<()>) = tokio::sync::broadcast::channel(1);
-    let vm_server =
-        avalanche_types::subnet::rpc::vm::server::Server::new(Box::new(vm::ChainVm::new()), stop_ch_tx);
+    let vm_server = avalanche_types::subnet::rpc::vm::server::Server::new(
+        Box::new(vm::ChainVm::new()),
+        stop_ch_tx,
+    );
 
     // start Vm service
     let vm_addr = utils::new_socket_addr();

--- a/spacesvm/tests/vm/mod.rs
+++ b/spacesvm/tests/vm/mod.rs
@@ -26,10 +26,8 @@ async fn test_api() {
 
     // setup stop channel for grpc services.
     let (stop_ch_tx, stop_ch_rx): (Sender<()>, Receiver<()>) = tokio::sync::broadcast::channel(1);
-    let vm_server = avalanche_types::subnet::rpc::vm::server::Server::new(
-        Box::new(vm::ChainVm::new()),
-        stop_ch_tx,
-    );
+    let vm_server =
+        avalanche_types::subnet::rpc::vm::server::Server::new(vm::ChainVm::new(), stop_ch_tx);
 
     // start Vm service
     let vm_addr = utils::new_socket_addr();
@@ -112,7 +110,7 @@ async fn test_api() {
         .await
         .unwrap();
 
-    let mut client = spacesvm::api::client::Client::new(http::Uri::from_static("http://test.url"));
+    let client = spacesvm::api::client::Client::new(http::Uri::from_static("http://test.url"));
 
     // ping
     let (_id, json_str) = client.raw_request("ping", &Params::None).await;

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -13,8 +13,8 @@ homepage = "https://avax.network"
 [dev-dependencies]
 avalanche-installer = "0.0.8"
 avalanche-network-runner-sdk = "0.3.0" # https://crates.io/crates/avalanche-network-runner-sdk
-avalanche-types = { version = "0.0.135", features = ["client", "subnet"] } # https://crates.io/crates/avalanche-types
-env_logger = "0.9.1"
+avalanche-types = { version = "0.0.140", features = ["client", "subnet"] } # https://crates.io/crates/avalanche-types
+env_logger = "0.10.0"
 log = "0.4.17"
 random-manager = "0.0.1"
 serde_json = "1.0.87" # https://github.com/serde-rs/json/releases

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -13,11 +13,11 @@ homepage = "https://avax.network"
 [dev-dependencies]
 avalanche-installer = "0.0.8"
 avalanche-network-runner-sdk = "0.3.0" # https://crates.io/crates/avalanche-network-runner-sdk
-avalanche-types = { version = "0.0.140", features = ["client", "subnet"] } # https://crates.io/crates/avalanche-types
+avalanche-types = { version = "0.0.144", features = ["client", "subnet"] } # https://crates.io/crates/avalanche-types
 env_logger = "0.10.0"
 log = "0.4.17"
 random-manager = "0.0.1"
 serde_json = "1.0.87" # https://github.com/serde-rs/json/releases
 tempfile = "3.3.0"
 spacesvm = { path = "../../spacesvm" }
-tokio = { version = "1.21.2", features = [] } # https://github.com/tokio-rs/tokio/releases
+tokio = { version = "1.22.0", features = [] } # https://github.com/tokio-rs/tokio/releases

--- a/tests/e2e/src/tests/mod.rs
+++ b/tests/e2e/src/tests/mod.rs
@@ -9,10 +9,7 @@ use avalanche_network_runner_sdk::{BlockchainSpec, Client, GlobalConfig, StartRe
 use avalanche_types::subnet;
 use spacesvm::{
     self,
-    api::{
-        client::{claim_tx, get_or_create_pk, Uri},
-        DecodeTxArgs,
-    },
+    api::client::{claim_tx, get_or_create_pk, Uri},
 };
 
 #[tokio::test]
@@ -199,9 +196,7 @@ async fn e2e() {
 
     log::info!("decode claim tx request...");
     let resp = scli
-        .decode_tx(DecodeTxArgs {
-            tx_data: claim_tx("test".to_owned()),
-        })
+        .decode_tx(claim_tx("test"))
         .await
         .expect("decodeTx success");
     log::info!("decode claim response from {}: {:?}", ep, resp);

--- a/tests/e2e/src/tests/mod.rs
+++ b/tests/e2e/src/tests/mod.rs
@@ -50,7 +50,7 @@ async fn e2e() {
         // keep this in sync with "proto" crate
         // ref. https://github.com/ava-labs/avalanchego/blob/v1.9.2/version/constants.go#L15-L17
         let (exec_path, plugins_dir) =
-            avalanche_installer::avalanchego::download(None, None, Some("v1.9.3".to_string()))
+            avalanche_installer::avalanchego::download(None, None, Some("v1.9.2".to_string()))
                 .await
                 .unwrap();
         avalanchego_exec_path = exec_path;

--- a/tests/e2e/src/tests/mod.rs
+++ b/tests/e2e/src/tests/mod.rs
@@ -194,14 +194,14 @@ async fn e2e() {
 
     let private_key = get_or_create_pk("/tmp/.spacesvm-cli-pk").expect("generate new private key");
     let chain_url = format!("{}/ext/bc/{}/public", rpc_eps[0], blockchain_id);
-    let mut scli =
-        spacesvm::api::client::Client::new(chain_url.parse::<Uri>().expect("valid endpoint"))
-            .set_private_key(private_key);
+    let scli =
+        spacesvm::api::client::Client::new(chain_url.parse::<Uri>().expect("valid endpoint"));
+    scli.set_private_key(private_key).await;
     for ep in rpc_eps.iter() {
         let chain_url = format!("{}/ext/bc/{}/public", ep, blockchain_id)
             .parse::<Uri>()
             .expect("valid endpoint");
-        scli.set_endpoint(chain_url);
+        scli.set_endpoint(chain_url).await;
         let resp = scli.ping().await.unwrap();
         log::info!("ping response from {}: {:?}", ep, resp);
         assert!(resp.success);
@@ -209,7 +209,8 @@ async fn e2e() {
         thread::sleep(Duration::from_millis(300));
     }
 
-    scli.set_endpoint(chain_url.parse::<Uri>().expect("valid endpoint"));
+    scli.set_endpoint(chain_url.parse::<Uri>().expect("valid endpoint"))
+        .await;
 
     log::info!("decode claim tx request...");
     let resp = scli

--- a/tests/e2e/src/tests/mod.rs
+++ b/tests/e2e/src/tests/mod.rs
@@ -217,7 +217,7 @@ async fn e2e() {
         .decode_tx(claim_tx("test"))
         .await
         .expect("decodeTx success");
-    log::info!("decode claim response from {}: {:?}", chain_url, resp);
+    log::info!("decode claim tx response from {}: {:?}", chain_url, resp);
 
     log::info!("issue claim tx request...");
     let resp = scli
@@ -231,14 +231,14 @@ async fn e2e() {
         .decode_tx(set_tx("test", "foo", "bar"))
         .await
         .expect("decodeTx success");
-    log::info!("decode set response from {}: {:?}", chain_url, resp);
+    log::info!("decode set tx response from {}: {:?}", chain_url, resp);
 
     log::info!("issue set tx request...");
     let resp = scli
         .issue_tx(&resp.typed_data)
         .await
         .expect("issue_tx success");
-    log::info!("issue tx tx response from {}: {:?}", chain_url, resp);
+    log::info!("issue set tx response from {}: {:?}", chain_url, resp);
 
     log::info!("issue resolve request...");
     let resp = scli.resolve("test", "foo").await.expect("resolve success");


### PR DESCRIPTION
This PR adds basic e2e testing for the api client to ensure no regressions in logic. More robust tests will be added once #85 merges.

Signed-off-by: Sam Batschelet <sam.batschelet@avalabs.org>